### PR TITLE
downgrade to scala 2.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
-    <scala.version>2.12</scala.version>
-    <spark.version>3.0.0</spark.version>
+    <scala.version>2.11</scala.version>
+    <spark.version>2.4.6</spark.version>
     <mysql.version>8.0.16</mysql.version>
     <informix-jdbc.version>4.10.8.1</informix-jdbc.version>
     <elasticsearch-hadoop.version>6.2.3</elasticsearch-hadoop.version>

--- a/src/main/java/net/jgp/books/spark/ch08/lab400_elasticsearch_Ingestion/ElasticsearchToDatasetApp.java
+++ b/src/main/java/net/jgp/books/spark/ch08/lab400_elasticsearch_Ingestion/ElasticsearchToDatasetApp.java
@@ -43,7 +43,7 @@ public class ElasticsearchToDatasetApp {
         .option("es.nodes", "localhost")
         .option("es.port", "9200")
         .option("es.query", "?q=*")
-        .option("es.read.field.as.array.include", "Inspection_Date")
+        .option("es.read.field.as.array.include", "Inspection_Date,Coord")
         .load("nyc_restaurants");
 
     long t2 = System.currentTimeMillis();


### PR DESCRIPTION
Elasticsearch Spark / Elasticsearch Hadoop libraries do not yet support Scala 2.12.  There exists an opened merge request (https://github.com/elastic/elasticsearch-hadoop/pull/1308) which is still open, so up until it is merged only Scala 2.11 can be used.
The following exceptions occurs if Scala 2.12 is used:
```
Exception in thread "main" java.lang.NoClassDefFoundError: scala/Product$class
	at org.elasticsearch.spark.sql.ElasticsearchRelation.<init>(DefaultSource.scala:215)
	at org.elasticsearch.spark.sql.DefaultSource.createRelation(DefaultSource.scala:93)
	at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:339)
	at org.apache.spark.sql.DataFrameReader.loadV1Source(DataFrameReader.scala:279)
	at org.apache.spark.sql.DataFrameReader.$anonfun$load$2(DataFrameReader.scala:268)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.sql.DataFrameReader.load(DataFrameReader.scala:268)
	at org.apache.spark.sql.DataFrameReader.load(DataFrameReader.scala:214)
	at net.jgp.books.spark.ch08.lab400_elasticsearch_Ingestion.ElasticsearchToDatasetApp.start(ElasticsearchToDatasetApp.java:47)
	at net.jgp.books.spark.ch08.lab400_elasticsearch_Ingestion.ElasticsearchToDatasetApp.main(ElasticsearchToDatasetApp.java:23)
Caused by: java.lang.ClassNotFoundException: scala.Product$class
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 10 more
```